### PR TITLE
fix: view hierarchy issues

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/analytics/Analytics.kt
+++ b/maestro-cli/src/main/java/maestro/cli/analytics/Analytics.kt
@@ -111,39 +111,39 @@ object Analytics : AutoCloseable {
      * This method is "fire and forget" - it will never block the calling thread
      */
     fun trackEvent(event: PostHogEvent) {
-        executor.submit {
-            try {
-                if (!analyticsStateManager.getState().enabled || analyticsDisabledWithEnvVar) return@submit
-
-                identifyUserIfNeeded()
-
-                // Include super properties in each event since PostHog Java client doesn't have register
-                val eventData = convertEventToEventData(event)
-                val userState = analyticsStateManager.getState()
-                val groupProperties = userState.orgId?.let { orgId ->
-                   mapOf(
-                       "\$groups" to mapOf(
-                           "company" to orgId
-                       )
-                   )
-                } ?: emptyMap()
-                val properties =
-                    eventData.properties +
-                    superProperties.toMap() +
-                    UserProperties.fromAnalyticsState(userState).toMap() +
-                    groupProperties
-
-                // Send Event
-                posthog.capture(
-                    uuid,
-                    eventData.eventName,
-                    properties
-                )
-            } catch (e: Exception) {
-                // Analytics failures should never break CLI functionality
-                logger.trace("Failed to track event ${event.name}: ${e.message}", e)
-            }
-        }
+//        executor.submit {
+//            try {
+//                if (!analyticsStateManager.getState().enabled || analyticsDisabledWithEnvVar) return@submit
+//
+//                identifyUserIfNeeded()
+//
+//                // Include super properties in each event since PostHog Java client doesn't have register
+//                val eventData = convertEventToEventData(event)
+//                val userState = analyticsStateManager.getState()
+//                val groupProperties = userState.orgId?.let { orgId ->
+//                   mapOf(
+//                       "\$groups" to mapOf(
+//                           "company" to orgId
+//                       )
+//                   )
+//                } ?: emptyMap()
+//                val properties =
+//                    eventData.properties +
+//                    superProperties.toMap() +
+//                    UserProperties.fromAnalyticsState(userState).toMap() +
+//                    groupProperties
+//
+//                // Send Event
+//                posthog.capture(
+//                    uuid,
+//                    eventData.eventName,
+//                    properties
+//                )
+//            } catch (e: Exception) {
+//                // Analytics failures should never break CLI functionality
+//                logger.trace("Failed to track event ${event.name}: ${e.message}", e)
+//            }
+//        }
     }
 
     /**

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -239,7 +239,8 @@ class XCTestDriverClient(
 
     private fun processResponse(response: Response, url: String): String {
         val responseBodyAsString = response.body?.bytes()?.let { bytes -> String(bytes) } ?: ""
-
+        logger.info("UIP - Processing response from URL: $url")
+        logger.info("UIP - Processed response: $responseBodyAsString")
         return if (!response.isSuccessful) {
             val code = response.code
             handleExceptions(code, url, responseBodyAsString)


### PR DESCRIPTION

## Proposed changes

This pull request introduces changes primarily aimed at improving debugging and reliability in the iOS device automation flow. The key updates include enhanced logging for better traceability and adjustments to the retry logic when fetching the view hierarchy, as well as a temporary disabling of analytics event tracking in the CLI.

**iOS Device Automation Improvements:**

* Increased the retry attempts from 3 to 5 when fetching the view hierarchy in `XCTestIOSDevice`, added more detailed logging for each attempt, and increased the delay between retries to 300ms to better handle transient errors.
* Added info-level logging to capture both the URL and response body when processing responses in `XCTestDriverClient`, making it easier to debug issues with device communication.

**CLI Analytics:**

* Temporarily disabled the asynchronous analytics event tracking in `Analytics.kt` by commenting out the executor logic, likely for debugging or to prevent side effects during development.

## Testing

<!--- Please describe how you tested your changes. -->

## Issues fixed
