### PR TITLE
fix: disable the exception firing on failure to handle reports

### DIFF
--- a/maestro-client/src/main/java/maestro/debuglog/DebugLogStore.kt
+++ b/maestro-client/src/main/java/maestro/debuglog/DebugLogStore.kt
@@ -86,10 +86,14 @@ object DebugLogStore {
     }
 
     fun finalizeRun() {
-        fileHandler.close()
-        val output = File(currentRunLogDirectory.parent, "${currentRunLogDirectory.name}.zip")
-        FileUtils.zipDir(currentRunLogDirectory.toPath(), output.toPath())
-        currentRunLogDirectory.deleteRecursively()
+        try {
+            fileHandler.close()
+            val output = File(currentRunLogDirectory.parent, "${currentRunLogDirectory.name}.zip")
+            FileUtils.zipDir(currentRunLogDirectory.toPath(), output.toPath())
+            currentRunLogDirectory.deleteRecursively()
+        } catch (e: Exception) {
+            // do nothing.
+        }
     }
 
     private fun logFile(named: String): File {


### PR DESCRIPTION
## Proposed changes

This step is usually throwing now because another spawned process has already handled the file.close though the other threads are unaware. 

## Testing

<!--- Please describe how you tested your changes. -->

## Issues fixed
