### PR TITLE
 Add multi-pass AI extraction with view hierarchy context and configu…

### DIFF
--- a/maestro-ai/src/main/java/maestro/ai/CloudPredictionAIEngine.kt
+++ b/maestro-ai/src/main/java/maestro/ai/CloudPredictionAIEngine.kt
@@ -1,7 +1,8 @@
 package maestro.ai
 
 import maestro.ai.cloud.Defect
-import maestro.ai.Prediction
+import maestro.ai.cloud.ExtractPointValidationResponse
+import maestro.ai.cloud.ExtractPointWithReasoningResponse
 
 class CloudAIPredictionEngine() : AIPredictionEngine {
     override suspend fun findDefects(screen: ByteArray, aiClient: AI): List<Defect> {
@@ -16,7 +17,20 @@ class CloudAIPredictionEngine() : AIPredictionEngine {
         return Prediction.extractText(aiClient, query, screen)
     }
 
+    @Suppress("DEPRECATION")
     override suspend fun extractPoint(screen: ByteArray, aiClient: AI, query: String): String {
         return Prediction.extractPoint(aiClient, query, screen)
+    }
+
+    override suspend fun extractPointWithReasoning(screen: ByteArray, aiClient: AI, query: String, viewHierarchy: String?): ExtractPointWithReasoningResponse? {
+        return Prediction.extractPointWithReasoning(aiClient, query, screen, viewHierarchy)
+    }
+
+    override suspend fun extractPointRefined(croppedScreen: ByteArray, aiClient: AI, query: String, contextDescription: String): ExtractPointWithReasoningResponse? {
+        return Prediction.extractPointRefined(aiClient, query, croppedScreen, contextDescription)
+    }
+
+    override suspend fun validatePoint(screen: ByteArray, aiClient: AI, query: String, pointXPercent: Int, pointYPercent: Int): ExtractPointValidationResponse? {
+        return Prediction.validatePoint(aiClient, query, screen, pointXPercent, pointYPercent)
     }
 }

--- a/maestro-ai/src/main/java/maestro/ai/IAPredictionEngine.kt
+++ b/maestro-ai/src/main/java/maestro/ai/IAPredictionEngine.kt
@@ -1,10 +1,15 @@
 package maestro.ai
 
 import maestro.ai.cloud.Defect
+import maestro.ai.cloud.ExtractPointValidationResponse
+import maestro.ai.cloud.ExtractPointWithReasoningResponse
 
 interface AIPredictionEngine {
     suspend fun findDefects(screen: ByteArray, aiClient: AI): List<Defect>
     suspend fun performAssertion(screen: ByteArray, aiClient: AI, assertion: String): Defect?
     suspend fun extractText(screen: ByteArray, aiClient: AI, query: String): String
     suspend fun extractPoint(screen: ByteArray, aiClient: AI, query: String): String
+    suspend fun extractPointWithReasoning(screen: ByteArray, aiClient: AI, query: String, viewHierarchy: String? = null): ExtractPointWithReasoningResponse?
+    suspend fun extractPointRefined(croppedScreen: ByteArray, aiClient: AI, query: String, contextDescription: String): ExtractPointWithReasoningResponse?
+    suspend fun validatePoint(screen: ByteArray, aiClient: AI, query: String, pointXPercent: Int, pointYPercent: Int): ExtractPointValidationResponse?
 }

--- a/maestro-ai/src/main/java/maestro/ai/Prediction.kt
+++ b/maestro-ai/src/main/java/maestro/ai/Prediction.kt
@@ -1,6 +1,8 @@
 package maestro.ai
 
 import maestro.ai.cloud.Defect
+import maestro.ai.cloud.ExtractPointValidationResponse
+import maestro.ai.cloud.ExtractPointWithReasoningResponse
 import maestro.ai.cloud.OpenAIClient
 
 object Prediction {
@@ -41,6 +43,7 @@ object Prediction {
         return ""
     }
 
+    @Deprecated("Use extractPointWithReasoning for improved accuracy", replaceWith = ReplaceWith("extractPointWithReasoning(aiClient, query, screen)"))
     suspend fun extractPoint(
         aiClient: AI?,
         query: String,
@@ -51,5 +54,42 @@ object Prediction {
             return response.text
         }
         return ""
+    }
+
+    suspend fun extractPointWithReasoning(
+        aiClient: AI?,
+        query: String,
+        screen: ByteArray,
+        viewHierarchy: String? = null,
+    ): ExtractPointWithReasoningResponse? {
+        if(aiClient !== null){
+            return openApi.extractPointWithAi(aiClient, query, screen, viewHierarchy)
+        }
+        return null
+    }
+
+    suspend fun extractPointRefined(
+        aiClient: AI?,
+        query: String,
+        croppedScreen: ByteArray,
+        contextDescription: String,
+    ): ExtractPointWithReasoningResponse? {
+        if(aiClient !== null){
+            return openApi.extractPointRefined(aiClient, query, croppedScreen, contextDescription)
+        }
+        return null
+    }
+
+    suspend fun validatePoint(
+        aiClient: AI?,
+        query: String,
+        screen: ByteArray,
+        pointXPercent: Int,
+        pointYPercent: Int,
+    ): ExtractPointValidationResponse? {
+        if(aiClient !== null){
+            return openApi.validatePoint(aiClient, query, screen, pointXPercent, pointYPercent)
+        }
+        return null
     }
 }

--- a/maestro-ai/src/main/java/maestro/ai/anthropic/Client.kt
+++ b/maestro-ai/src/main/java/maestro/ai/anthropic/Client.kt
@@ -25,7 +25,7 @@ private const val API_URL = "https://api.anthropic.com/v1/messages"
 private val logger = LoggerFactory.getLogger(Claude::class.java)
 
 class Claude(
-    defaultModel: String = "claude-3-5-sonnet-20240620",
+    defaultModel: String = "claude-sonnet-4-5-20250929",
     httpClient: HttpClient = defaultHttpClient,
     private val apiKey: String,
     private val defaultTemperature: Float = 0.2f,

--- a/maestro-ai/src/main/java/maestro/ai/cloud/ApiClient.kt
+++ b/maestro-ai/src/main/java/maestro/ai/cloud/ApiClient.kt
@@ -48,6 +48,21 @@ data class ExtractPointWithAiResponse(
     val text: String,
 )
 
+@Serializable
+data class ExtractPointWithReasoningResponse(
+    val reasoning: String,
+    val description: String,
+    val boundingRegion: String,
+    val text: String,
+)
+
+@Serializable
+data class ExtractPointValidationResponse(
+    val isCorrect: Boolean,
+    val correctedText: String,
+    val reasoning: String,
+)
+
 class ApiClient {
     private val baseUrl by lazy {
         System.getenv("MAESTRO_CLOUD_API_URL") ?: "https://api.copilot.mobile.dev"

--- a/maestro-ai/src/main/java/maestro/ai/openai/Client.kt
+++ b/maestro-ai/src/main/java/maestro/ai/openai/Client.kt
@@ -22,7 +22,7 @@ private const val API_URL = "https://api.openai.com/v1/chat/completions"
 private val logger = LoggerFactory.getLogger(OpenAI::class.java)
 
 class OpenAI(
-    defaultModel: String = "gpt-4o",
+    defaultModel: String = "gpt-4.1",
     httpClient: HttpClient = defaultHttpClient,
     private val apiKey: String,
     private val defaultTemperature: Float = 0.2f,

--- a/maestro-ai/src/main/resources/extractPointValidation_schema.json
+++ b/maestro-ai/src/main/resources/extractPointValidation_schema.json
@@ -1,0 +1,25 @@
+{
+  "name": "extractPointValidation",
+  "description": "Validates or corrects a proposed point location on a screenshot",
+  "strict": true,
+  "schema": {
+    "type": "object",
+    "required": [
+      "isCorrect",
+      "correctedText",
+      "reasoning"
+    ],
+    "additionalProperties": false,
+    "properties": {
+      "isCorrect": {
+        "type": "boolean"
+      },
+      "correctedText": {
+        "type": "string"
+      },
+      "reasoning": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/maestro-ai/src/main/resources/extractPointWithReasoning_schema.json
+++ b/maestro-ai/src/main/resources/extractPointWithReasoning_schema.json
@@ -1,0 +1,29 @@
+{
+  "name": "extractPointWithReasoning",
+  "description": "Extracts center point coordinates with reasoning from an image based on a given query",
+  "strict": true,
+  "schema": {
+    "type": "object",
+    "required": [
+      "reasoning",
+      "description",
+      "boundingRegion",
+      "text"
+    ],
+    "additionalProperties": false,
+    "properties": {
+      "reasoning": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "boundingRegion": {
+        "type": "string"
+      },
+      "text": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -670,6 +670,7 @@ data class AssertWithAICommand(
 data class ExtractPointWithAICommand(
     val query: String,
     val outputVariable: String,
+    val passes: Int = 3,
     override val optional: Boolean = true,
     override val label: String? = null
 ) : Command {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -670,7 +670,7 @@ data class AssertWithAICommand(
 data class ExtractPointWithAICommand(
     val query: String,
     val outputVariable: String,
-    val passes: Int = 3,
+    val passes: Int = 1,
     override val optional: Boolean = true,
     override val label: String? = null
 ) : Command {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/util/ImageCropUtil.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/util/ImageCropUtil.kt
@@ -1,0 +1,87 @@
+package maestro.orchestra.util
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+data class CropResult(
+    val croppedPng: ByteArray,
+    val cropX1: Int,
+    val cropY1: Int,
+    val cropX2: Int,
+    val cropY2: Int,
+    val originalWidth: Int,
+    val originalHeight: Int,
+)
+
+object ImageCropUtil {
+
+    fun cropAroundPoint(
+        screenshotPng: ByteArray,
+        centerXPercent: Int,
+        centerYPercent: Int,
+        cropPercent: Int = 30,
+    ): CropResult {
+        val image = ImageIO.read(ByteArrayInputStream(screenshotPng))
+        val width = image.width
+        val height = image.height
+
+        val centerX = (centerXPercent * width) / 100
+        val centerY = (centerYPercent * height) / 100
+
+        val cropW = (cropPercent * width) / 100
+        val cropH = (cropPercent * height) / 100
+
+        val x1 = (centerX - cropW / 2).coerceIn(0, width - 1)
+        val y1 = (centerY - cropH / 2).coerceIn(0, height - 1)
+        val x2 = (x1 + cropW).coerceAtMost(width)
+        val y2 = (y1 + cropH).coerceAtMost(height)
+
+        val actualW = x2 - x1
+        val actualH = y2 - y1
+
+        if (actualW <= 0 || actualH <= 0) {
+            return CropResult(
+                croppedPng = screenshotPng,
+                cropX1 = 0,
+                cropY1 = 0,
+                cropX2 = width,
+                cropY2 = height,
+                originalWidth = width,
+                originalHeight = height,
+            )
+        }
+
+        val cropped = image.getSubimage(x1, y1, actualW, actualH)
+        val outputStream = ByteArrayOutputStream()
+        ImageIO.write(cropped, "png", outputStream)
+
+        return CropResult(
+            croppedPng = outputStream.toByteArray(),
+            cropX1 = x1,
+            cropY1 = y1,
+            cropX2 = x2,
+            cropY2 = y2,
+            originalWidth = width,
+            originalHeight = height,
+        )
+    }
+
+    fun mapCroppedPercentToOriginalPercent(
+        croppedXPercent: Int,
+        croppedYPercent: Int,
+        crop: CropResult,
+    ): Pair<Int, Int> {
+        val cropW = crop.cropX2 - crop.cropX1
+        val cropH = crop.cropY2 - crop.cropY1
+
+        val absoluteX = crop.cropX1 + (croppedXPercent * cropW) / 100
+        val absoluteY = crop.cropY1 + (croppedYPercent * cropH) / 100
+
+        val originalXPercent = ((absoluteX * 100) / crop.originalWidth).coerceIn(0, 100)
+        val originalYPercent = ((absoluteY * 100) / crop.originalHeight).coerceIn(0, 100)
+
+        return Pair(originalXPercent, originalYPercent)
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/util/ViewHierarchySerializer.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/util/ViewHierarchySerializer.kt
@@ -1,0 +1,47 @@
+package maestro.orchestra.util
+
+import maestro.TreeNode
+
+object ViewHierarchySerializer {
+
+    fun serialize(root: TreeNode, maxNodes: Int = 150): String {
+        val lines = mutableListOf<String>()
+        collectNodes(root, depth = 0, lines = lines, maxNodes = maxNodes)
+        return lines.joinToString("\n")
+    }
+
+    private fun collectNodes(
+        node: TreeNode,
+        depth: Int,
+        lines: MutableList<String>,
+        maxNodes: Int,
+    ) {
+        if (lines.size >= maxNodes) return
+
+        val text = node.attributes["text"]?.takeIf { it.isNotBlank() }
+        val a11y = node.attributes["accessibilityText"]?.takeIf { it.isNotBlank() }
+        val resourceId = node.attributes["resource-id"]?.takeIf { it.isNotBlank() }
+        val bounds = node.attributes["bounds"]?.takeIf { it.isNotBlank() }
+        val clickable = node.clickable == true
+
+        val hasMeaningfulContent = text != null || a11y != null || resourceId != null || clickable
+
+        if (hasMeaningfulContent) {
+            val indent = "  ".repeat(depth)
+            val parts = mutableListOf<String>()
+
+            if (bounds != null) parts.add(bounds)
+            if (text != null) parts.add("text=\"$text\"")
+            if (a11y != null) parts.add("a11y=\"$a11y\"")
+            if (resourceId != null) parts.add("rid=\"$resourceId\"")
+            if (clickable) parts.add("[clickable]")
+
+            lines.add("$indent${parts.joinToString(" ")}")
+        }
+
+        for (child in node.children) {
+            if (lines.size >= maxNodes) break
+            collectNodes(child, depth + if (hasMeaningfulContent) 1 else 0, lines, maxNodes)
+        }
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlExtractPointWithAI.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlExtractPointWithAI.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 data class YamlExtractPointWithAI(
     val query: String,
     val outputVariable: String = "aiOutput",
-    val passes: Int = 3,
+    val passes: Int = 1,
     val optional: Boolean = true,
     val label: String? = null,
 ) {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlExtractPointWithAI.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlExtractPointWithAI.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 data class YamlExtractPointWithAI(
     val query: String,
     val outputVariable: String = "aiOutput",
+    val passes: Int = 3,
     val optional: Boolean = true,
     val label: String? = null,
 ) {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -244,6 +244,7 @@ data class YamlFluentCommand(
                     ExtractPointWithAICommand(
                         query = extractPointWithAI.query,
                         outputVariable = extractPointWithAI.outputVariable,
+                        passes = extractPointWithAI.passes,
                         optional = extractPointWithAI.optional,
                         label = extractPointWithAI.label,
                     )


### PR DESCRIPTION
## Proposed changes

https://goeuro.atlassian.net/browse/UP-4292

Summary                    

  Improves extractPointWithAI accuracy by replacing the single AI call with a multi-pass approach (up to 3 passes) that combines enhanced prompting, view hierarchy context, crop  
  refinement, and validation.
                                                                                                                                                                                   
  What changed                                                                                     

Pass 1 — Initial Extraction

Takes a screenshot and the screen's UI hierarchy (all buttons, text, etc. with their positions). Sends both to the AI with a chain-of-thought prompt asking it to reason step by step about where the element is. Returns coordinates and an approximate bounding region.

Pass 2 — Crop Refinement

Crops a zoomed-in region (30% of screen) around the Pass 1 result and sends it back to the AI. Since the element appears larger in the cropped image, the AI can pinpoint it more precisely. Coordinates are mapped back to the full screen.

Pass 3 — Validation

Sends the full screenshot again with the refined coordinates and asks the AI to confirm or correct them. Acts as a sanity check to catch any big mistakes from earlier passes.

Each pass is wrapped in error handling — if any pass fails, the best result so far is used.

Configurable passes

  The number of passes is configurable (1-3, default 3) to balance accuracy vs speed:
  - passes: 1 — fastest, just the enhanced prompt with view hierarchy
  - passes: 2 — adds crop refinement
  - passes: 3 — full pipeline with validation (default)

Usage

  # Default (3 passes)
  - extractPointWithAI:
      query: "Save passenger details toggle"
      outputVariable: POINT

  # Faster with fewer passes
  - extractPointWithAI:
      query: "Save passenger details toggle"
      outputVariable: POINT
      passes: 1 or 2

  # Tap on the result
  - tapOn:
      point: "${POINT}"

Other changes

  - Updated default OpenAI model from gpt-4o to gpt-4.1
  - Updated default Anthropic model from claude-3-5-sonnet-20240620 to claude-sonnet-4-5-20250929

## Testing

Tested with a dummy flow that was able to locate all 4 components with a `Passes = 1` Video attached

https://github.com/user-attachments/assets/00d1cf92-b9c6-4094-884d-7a0d2a0bad66


