### PR TITLE
Add extractComponentWithAI command for image-based UI element location

### DIFF
--- a/maestro-ai/src/main/java/maestro/ai/CloudPredictionAIEngine.kt
+++ b/maestro-ai/src/main/java/maestro/ai/CloudPredictionAIEngine.kt
@@ -33,4 +33,8 @@ class CloudAIPredictionEngine() : AIPredictionEngine {
     override suspend fun validatePoint(screen: ByteArray, aiClient: AI, query: String, pointXPercent: Int, pointYPercent: Int): ExtractPointValidationResponse? {
         return Prediction.validatePoint(aiClient, query, screen, pointXPercent, pointYPercent)
     }
+
+    override suspend fun extractComponentPoint(componentImage: ByteArray, screen: ByteArray, aiClient: AI, viewHierarchy: String?): ExtractPointWithReasoningResponse? {
+        return Prediction.extractComponentPoint(aiClient, componentImage, screen, viewHierarchy)
+    }
 }

--- a/maestro-ai/src/main/java/maestro/ai/IAPredictionEngine.kt
+++ b/maestro-ai/src/main/java/maestro/ai/IAPredictionEngine.kt
@@ -12,4 +12,5 @@ interface AIPredictionEngine {
     suspend fun extractPointWithReasoning(screen: ByteArray, aiClient: AI, query: String, viewHierarchy: String? = null): ExtractPointWithReasoningResponse?
     suspend fun extractPointRefined(croppedScreen: ByteArray, aiClient: AI, query: String, contextDescription: String): ExtractPointWithReasoningResponse?
     suspend fun validatePoint(screen: ByteArray, aiClient: AI, query: String, pointXPercent: Int, pointYPercent: Int): ExtractPointValidationResponse?
+    suspend fun extractComponentPoint(componentImage: ByteArray, screen: ByteArray, aiClient: AI, viewHierarchy: String? = null): ExtractPointWithReasoningResponse?
 }

--- a/maestro-ai/src/main/java/maestro/ai/Prediction.kt
+++ b/maestro-ai/src/main/java/maestro/ai/Prediction.kt
@@ -80,6 +80,18 @@ object Prediction {
         return null
     }
 
+    suspend fun extractComponentPoint(
+        aiClient: AI?,
+        componentImage: ByteArray,
+        screen: ByteArray,
+        viewHierarchy: String? = null,
+    ): ExtractPointWithReasoningResponse? {
+        if(aiClient !== null){
+            return openApi.extractComponentPoint(aiClient, componentImage, screen, viewHierarchy)
+        }
+        return null
+    }
+
     suspend fun validatePoint(
         aiClient: AI?,
         query: String,

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -694,6 +694,32 @@ data class ExtractPointWithAICommand(
     }
 }
 
+data class ExtractComponentWithAICommand(
+    val imagePath: String,
+    val outputVariable: String,
+    override val optional: Boolean = true,
+    override val label: String? = null
+) : Command {
+    override val originalDescription: String
+        get() = "Extract component with AI: $imagePath"
+    override fun yamlString(): String {
+        val yamlString = buildString {
+            appendLine(
+                """
+                |extractComponentWithAI
+                """
+            )
+        }
+        return yamlString
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+        return copy(
+            imagePath = imagePath.evaluateScripts(jsEngine),
+        )
+    }
+}
+
 data class ExtractTextWithAICommand(
     val query: String,
     val outputVariable: String,

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -41,6 +41,7 @@ data class MaestroCommand(
     val assertWithAICommand: AssertWithAICommand? = null,
     val extractTextWithAICommand: ExtractTextWithAICommand? = null,
     val extractPointWithAICommand: ExtractPointWithAICommand? = null,
+    val extractComponentWithAICommand: ExtractComponentWithAICommand? = null,
     val inputTextCommand: InputTextCommand? = null,
     val inputRandomTextCommand: InputRandomCommand? = null,
     val launchAppCommand: LaunchAppCommand? = null,
@@ -89,6 +90,7 @@ data class MaestroCommand(
         assertWithAICommand = command as? AssertWithAICommand,
         extractTextWithAICommand = command as? ExtractTextWithAICommand,
         extractPointWithAICommand = command as? ExtractPointWithAICommand,
+        extractComponentWithAICommand = command as? ExtractComponentWithAICommand,
         inputTextCommand = command as? InputTextCommand,
         inputRandomTextCommand = command as? InputRandomCommand,
         assertVisualCommand = command as? AssertVisualCommand,
@@ -138,6 +140,7 @@ data class MaestroCommand(
         assertWithAICommand != null -> assertWithAICommand
         extractTextWithAICommand != null -> extractTextWithAICommand
         extractPointWithAICommand != null -> extractPointWithAICommand
+        extractComponentWithAICommand != null -> extractComponentWithAICommand
         inputTextCommand != null -> inputTextCommand
         inputRandomTextCommand != null -> inputRandomTextCommand
         launchAppCommand != null -> launchAppCommand

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -707,8 +707,16 @@ class Orchestra(
         val reasoningLog = StringBuilder()
         reasoningLog.appendLine("Image: \"${command.imagePath}\"")
 
-        // Read component image bytes
-        val componentImageBytes = File(command.imagePath).readBytes()
+        // Resolve image path: if relative and APP_ROOT is set, resolve against it
+        val imageFile = File(command.imagePath).let { file ->
+            if (file.isAbsolute) file
+            else {
+                val appRoot = System.getenv("APP_ROOT")
+                if (appRoot != null) File(appRoot, command.imagePath)
+                else file
+            }
+        }
+        val componentImageBytes = imageFile.readBytes()
 
         // Take screenshot
         val imageData = Buffer()

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -397,6 +397,7 @@ class Orchestra(
             is AssertWithAICommand -> assertWithAICommand(command, maestroCommand)
             is ExtractTextWithAICommand -> extractTextWithAICommand(command, maestroCommand)
             is ExtractPointWithAICommand -> extractPointWithAICommand(command, maestroCommand)
+            is ExtractComponentWithAICommand -> extractComponentWithAICommand(command, maestroCommand)
             is InputTextCommand -> inputTextCommand(command)
             is InputRandomCommand -> inputTextRandomCommand(command)
             is LaunchAppCommand -> launchAppCommand(command)
@@ -695,6 +696,63 @@ class Orchestra(
             logger.warn("Failed to parse percentage point from '$text', defaulting to 50,50", e)
             Pair(50, 50)
         }
+    }
+
+    private suspend fun extractComponentWithAICommand(
+        command: ExtractComponentWithAICommand,
+        maestroCommand: MaestroCommand
+    ): Boolean {
+
+        val metadata = getMetadata(maestroCommand)
+        val reasoningLog = StringBuilder()
+        reasoningLog.appendLine("Image: \"${command.imagePath}\"")
+
+        // Read component image bytes
+        val componentImageBytes = File(command.imagePath).readBytes()
+
+        // Take screenshot
+        val imageData = Buffer()
+        maestro.takeScreenshot(imageData, compressed = false)
+        val screenshotBytes = imageData.copy().readByteArray()
+
+        // Serialize view hierarchy for context
+        val hierarchy = maestro.viewHierarchy()
+        val serializedHierarchy = ViewHierarchySerializer.serialize(hierarchy.root)
+
+        // --- PASS 1: Initial extraction with component image + screenshot + hierarchy ---
+        var bestPoint = "50%,50%"
+        reasoningLog.appendLine("\n--- Pass 1: Initial extraction ---")
+        val pass1Response = try {
+            AIPredictionEngine.extractComponentPoint(
+                componentImage = componentImageBytes,
+                screen = screenshotBytes,
+                aiClient = ai,
+                viewHierarchy = serializedHierarchy,
+            )
+        } catch (e: Exception) {
+            logger.warn("Pass 1 failed, using default point", e)
+            reasoningLog.appendLine("Pass 1 FAILED: ${e.message}")
+            null
+        }
+
+        if (pass1Response != null) {
+            bestPoint = pass1Response.text
+            reasoningLog.appendLine("Reasoning: ${pass1Response.reasoning}")
+            reasoningLog.appendLine("Description: ${pass1Response.description}")
+            reasoningLog.appendLine("Bounding region: ${pass1Response.boundingRegion}")
+            reasoningLog.appendLine("Point: ${pass1Response.text}")
+        }
+
+        reasoningLog.appendLine("\nFinal point: $bestPoint")
+
+        updateMetadata(
+            maestroCommand, metadata.copy(
+                aiReasoning = reasoningLog.toString()
+            )
+        )
+        jsEngine.putEnv(command.outputVariable, bestPoint)
+
+        return false
     }
 
     private fun evalScriptCommand(command: EvalScriptCommand): Boolean {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlExtractComponentWithAI.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlExtractComponentWithAI.kt
@@ -1,0 +1,23 @@
+package maestro.orchestra.yaml
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+data class YamlExtractComponentWithAI(
+    val image: String,
+    val outputVariable: String = "aiOutput",
+    val optional: Boolean = true,
+    val label: String? = null,
+) {
+
+    companion object {
+
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(image: String): YamlExtractComponentWithAI {
+            return YamlExtractComponentWithAI(
+                image = image,
+                optional = true,
+            )
+        }
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -254,11 +254,10 @@ data class YamlFluentCommand(
             )
 
             extractComponentWithAI != null -> {
-                val resolvedImagePath = resolveImagePath(flowPath, extractComponentWithAI.image)
                 listOf(
                     MaestroCommand(
                         ExtractComponentWithAICommand(
-                            imagePath = resolvedImagePath,
+                            imagePath = extractComponentWithAI.image,
                             outputVariable = extractComponentWithAI.outputVariable,
                             optional = extractComponentWithAI.optional,
                             label = extractComponentWithAI.label,
@@ -736,19 +735,6 @@ data class YamlFluentCommand(
             throw InvalidFlowFile("Flow file can't be a directory: ${resolvedPath.toUri()}", resolvedPath)
         }
         return resolvedPath
-    }
-
-    private fun resolveImagePath(flowPath: Path, imagePath: String): String {
-        val path = flowPath.fileSystem.getPath(imagePath)
-        val resolvedPath = if (path.isAbsolute) {
-            path
-        } else {
-            flowPath.resolveSibling(path).toAbsolutePath()
-        }
-        if (!resolvedPath.exists()) {
-            throw MediaFileNotFound("Image file at $imagePath in flow file: $flowPath not found", path)
-        }
-        return resolvedPath.absolutePathString()
     }
 
     private fun extendedWait(command: YamlExtendedWaitUntil): MaestroCommand {


### PR DESCRIPTION
### Summary 
                                                                                                                                                                                                                
- Adds a new extractComponentWithAI command that locates a UI component on screen using a reference image (e.g. Storybook snapshot)                                                                                                  
- The AI receives two images — the reference component and the current device screenshot — and returns center coordinates in x%,y% format
- Follows the same architecture as extractPointWithAI (YAML model, command, Orchestra execution, AI client chain)

Usage

- extractComponentWithAI:
    image: "./snapshots/save-toggle.png"
    outputVariable: POINT

- tapOn:
    point: "${POINT}"


## Testing

https://github.com/user-attachments/assets/773ae396-c538-46ae-bcb4-8e6f670886a5



