### PR TITLE
Add AI speed & accuracy metrics with HTML report and auto provider alternation

### DIFF
--- a/maestro-ai/src/main/java/maestro/ai/AI.kt
+++ b/maestro-ai/src/main/java/maestro/ai/AI.kt
@@ -14,6 +14,7 @@ data class CompletionData(
     val maxTokens: Int,
     val images: List<String>,
     val response: String,
+    val durationMs: Long = 0,
 )
 
 abstract class AI(

--- a/maestro-ai/src/main/java/maestro/ai/CloudPredictionAIEngine.kt
+++ b/maestro-ai/src/main/java/maestro/ai/CloudPredictionAIEngine.kt
@@ -1,19 +1,22 @@
 package maestro.ai
 
+import maestro.ai.cloud.AIResponse
 import maestro.ai.cloud.Defect
 import maestro.ai.cloud.ExtractPointValidationResponse
 import maestro.ai.cloud.ExtractPointWithReasoningResponse
+import maestro.ai.cloud.ExtractTextWithAiResponse
+import maestro.ai.cloud.FindDefectsResponse
 
 class CloudAIPredictionEngine() : AIPredictionEngine {
-    override suspend fun findDefects(screen: ByteArray, aiClient: AI): List<Defect> {
+    override suspend fun findDefects(screen: ByteArray, aiClient: AI): AIResponse<FindDefectsResponse> {
         return Prediction.findDefects(aiClient, screen)
     }
 
-    override suspend fun performAssertion(screen: ByteArray, aiClient: AI, assertion: String): Defect? {
+    override suspend fun performAssertion(screen: ByteArray, aiClient: AI, assertion: String): AIResponse<FindDefectsResponse> {
         return Prediction.performAssertion(aiClient, screen, assertion)
     }
 
-    override suspend fun extractText(screen: ByteArray, aiClient: AI, query: String): String {
+    override suspend fun extractText(screen: ByteArray, aiClient: AI, query: String): AIResponse<ExtractTextWithAiResponse> {
         return Prediction.extractText(aiClient, query, screen)
     }
 
@@ -22,19 +25,19 @@ class CloudAIPredictionEngine() : AIPredictionEngine {
         return Prediction.extractPoint(aiClient, query, screen)
     }
 
-    override suspend fun extractPointWithReasoning(screen: ByteArray, aiClient: AI, query: String, viewHierarchy: String?): ExtractPointWithReasoningResponse? {
+    override suspend fun extractPointWithReasoning(screen: ByteArray, aiClient: AI, query: String, viewHierarchy: String?): AIResponse<ExtractPointWithReasoningResponse>? {
         return Prediction.extractPointWithReasoning(aiClient, query, screen, viewHierarchy)
     }
 
-    override suspend fun extractPointRefined(croppedScreen: ByteArray, aiClient: AI, query: String, contextDescription: String): ExtractPointWithReasoningResponse? {
+    override suspend fun extractPointRefined(croppedScreen: ByteArray, aiClient: AI, query: String, contextDescription: String): AIResponse<ExtractPointWithReasoningResponse>? {
         return Prediction.extractPointRefined(aiClient, query, croppedScreen, contextDescription)
     }
 
-    override suspend fun validatePoint(screen: ByteArray, aiClient: AI, query: String, pointXPercent: Int, pointYPercent: Int): ExtractPointValidationResponse? {
+    override suspend fun validatePoint(screen: ByteArray, aiClient: AI, query: String, pointXPercent: Int, pointYPercent: Int): AIResponse<ExtractPointValidationResponse>? {
         return Prediction.validatePoint(aiClient, query, screen, pointXPercent, pointYPercent)
     }
 
-    override suspend fun extractComponentPoint(componentImage: ByteArray, screen: ByteArray, aiClient: AI, viewHierarchy: String?): ExtractPointWithReasoningResponse? {
+    override suspend fun extractComponentPoint(componentImage: ByteArray, screen: ByteArray, aiClient: AI, viewHierarchy: String?): AIResponse<ExtractPointWithReasoningResponse>? {
         return Prediction.extractComponentPoint(aiClient, componentImage, screen, viewHierarchy)
     }
 }

--- a/maestro-ai/src/main/java/maestro/ai/DemoApp.kt
+++ b/maestro-ai/src/main/java/maestro/ai/DemoApp.kt
@@ -126,15 +126,14 @@ class DemoApp : CliktCommand() {
                 val defects = if (testCase.prompt == null) Prediction.findDefects(
                     aiClient = aiClient,
                     screen = bytes,
-                ) else {
+                ).result.defects else {
                     val result = Prediction.performAssertion(
                         aiClient = aiClient,
                         screen = bytes,
                         assertion = testCase.prompt,
                     )
 
-                    if (result == null) emptyList()
-                    else listOf(result)
+                    result.result.defects
                 }
 
                 verify(testCase, defects)

--- a/maestro-ai/src/main/java/maestro/ai/IAPredictionEngine.kt
+++ b/maestro-ai/src/main/java/maestro/ai/IAPredictionEngine.kt
@@ -1,16 +1,19 @@
 package maestro.ai
 
+import maestro.ai.cloud.AIResponse
 import maestro.ai.cloud.Defect
 import maestro.ai.cloud.ExtractPointValidationResponse
 import maestro.ai.cloud.ExtractPointWithReasoningResponse
+import maestro.ai.cloud.ExtractTextWithAiResponse
+import maestro.ai.cloud.FindDefectsResponse
 
 interface AIPredictionEngine {
-    suspend fun findDefects(screen: ByteArray, aiClient: AI): List<Defect>
-    suspend fun performAssertion(screen: ByteArray, aiClient: AI, assertion: String): Defect?
-    suspend fun extractText(screen: ByteArray, aiClient: AI, query: String): String
+    suspend fun findDefects(screen: ByteArray, aiClient: AI): AIResponse<FindDefectsResponse>
+    suspend fun performAssertion(screen: ByteArray, aiClient: AI, assertion: String): AIResponse<FindDefectsResponse>
+    suspend fun extractText(screen: ByteArray, aiClient: AI, query: String): AIResponse<ExtractTextWithAiResponse>
     suspend fun extractPoint(screen: ByteArray, aiClient: AI, query: String): String
-    suspend fun extractPointWithReasoning(screen: ByteArray, aiClient: AI, query: String, viewHierarchy: String? = null): ExtractPointWithReasoningResponse?
-    suspend fun extractPointRefined(croppedScreen: ByteArray, aiClient: AI, query: String, contextDescription: String): ExtractPointWithReasoningResponse?
-    suspend fun validatePoint(screen: ByteArray, aiClient: AI, query: String, pointXPercent: Int, pointYPercent: Int): ExtractPointValidationResponse?
-    suspend fun extractComponentPoint(componentImage: ByteArray, screen: ByteArray, aiClient: AI, viewHierarchy: String? = null): ExtractPointWithReasoningResponse?
+    suspend fun extractPointWithReasoning(screen: ByteArray, aiClient: AI, query: String, viewHierarchy: String? = null): AIResponse<ExtractPointWithReasoningResponse>?
+    suspend fun extractPointRefined(croppedScreen: ByteArray, aiClient: AI, query: String, contextDescription: String): AIResponse<ExtractPointWithReasoningResponse>?
+    suspend fun validatePoint(screen: ByteArray, aiClient: AI, query: String, pointXPercent: Int, pointYPercent: Int): AIResponse<ExtractPointValidationResponse>?
+    suspend fun extractComponentPoint(componentImage: ByteArray, screen: ByteArray, aiClient: AI, viewHierarchy: String? = null): AIResponse<ExtractPointWithReasoningResponse>?
 }

--- a/maestro-ai/src/main/java/maestro/ai/Prediction.kt
+++ b/maestro-ai/src/main/java/maestro/ai/Prediction.kt
@@ -1,8 +1,11 @@
 package maestro.ai
 
+import maestro.ai.cloud.AIResponse
 import maestro.ai.cloud.Defect
 import maestro.ai.cloud.ExtractPointValidationResponse
 import maestro.ai.cloud.ExtractPointWithReasoningResponse
+import maestro.ai.cloud.ExtractTextWithAiResponse
+import maestro.ai.cloud.FindDefectsResponse
 import maestro.ai.cloud.OpenAIClient
 
 object Prediction {
@@ -11,36 +14,33 @@ object Prediction {
     suspend fun findDefects(
         aiClient: AI?,
         screen: ByteArray,
-    ): List<Defect> {
+    ): AIResponse<FindDefectsResponse> {
         if(aiClient !== null){
-            val response = openApi.findDefects(aiClient, screen)
-            return response.defects
+            return openApi.findDefects(aiClient, screen)
         }
-        return listOf()
+        return AIResponse(result = FindDefectsResponse(defects = listOf()), durationMs = 0, model = "none")
     }
 
     suspend fun performAssertion(
         aiClient: AI?,
         screen: ByteArray,
         assertion: String,
-    ): Defect? {
+    ): AIResponse<FindDefectsResponse> {
         if(aiClient !== null){
-            val response = openApi.findDefects(aiClient, screen, assertion)
-            return response.defects.firstOrNull()
+            return openApi.findDefects(aiClient, screen, assertion)
         }
-        return null
+        return AIResponse(result = FindDefectsResponse(defects = listOf()), durationMs = 0, model = "none")
     }
 
     suspend fun extractText(
         aiClient: AI?,
         query: String,
         screen: ByteArray,
-    ): String {
+    ): AIResponse<ExtractTextWithAiResponse> {
         if(aiClient !== null){
-            val response = openApi.extractTextWithAi(aiClient, query, screen)
-            return response.text
+            return openApi.extractTextWithAi(aiClient, query, screen)
         }
-        return ""
+        return AIResponse(result = ExtractTextWithAiResponse(text = ""), durationMs = 0, model = "none")
     }
 
     @Deprecated("Use extractPointWithReasoning for improved accuracy", replaceWith = ReplaceWith("extractPointWithReasoning(aiClient, query, screen)"))
@@ -51,7 +51,7 @@ object Prediction {
     ): String {
         if(aiClient !== null){
             val response = openApi.extractPointWithAi(aiClient, query, screen)
-            return response.text
+            return response.result.text
         }
         return ""
     }
@@ -61,7 +61,7 @@ object Prediction {
         query: String,
         screen: ByteArray,
         viewHierarchy: String? = null,
-    ): ExtractPointWithReasoningResponse? {
+    ): AIResponse<ExtractPointWithReasoningResponse>? {
         if(aiClient !== null){
             return openApi.extractPointWithAi(aiClient, query, screen, viewHierarchy)
         }
@@ -73,7 +73,7 @@ object Prediction {
         query: String,
         croppedScreen: ByteArray,
         contextDescription: String,
-    ): ExtractPointWithReasoningResponse? {
+    ): AIResponse<ExtractPointWithReasoningResponse>? {
         if(aiClient !== null){
             return openApi.extractPointRefined(aiClient, query, croppedScreen, contextDescription)
         }
@@ -85,7 +85,7 @@ object Prediction {
         componentImage: ByteArray,
         screen: ByteArray,
         viewHierarchy: String? = null,
-    ): ExtractPointWithReasoningResponse? {
+    ): AIResponse<ExtractPointWithReasoningResponse>? {
         if(aiClient !== null){
             return openApi.extractComponentPoint(aiClient, componentImage, screen, viewHierarchy)
         }
@@ -98,7 +98,7 @@ object Prediction {
         screen: ByteArray,
         pointXPercent: Int,
         pointYPercent: Int,
-    ): ExtractPointValidationResponse? {
+    ): AIResponse<ExtractPointValidationResponse>? {
         if(aiClient !== null){
             return openApi.validatePoint(aiClient, query, screen, pointXPercent, pointYPercent)
         }

--- a/maestro-ai/src/main/java/maestro/ai/anthropic/Client.kt
+++ b/maestro-ai/src/main/java/maestro/ai/anthropic/Client.kt
@@ -70,6 +70,7 @@ class Claude(
             messages = listOf(Message("user", imageContents + textContent)),
         )
 
+        val startTime = System.currentTimeMillis()
         val response = try {
             val httpResponse = httpClient.post(API_URL) {
                 contentType(ContentType.Application.Json)
@@ -96,6 +97,7 @@ class Claude(
             logger.error("Failed to complete request to Anthropic", e)
             throw e
         }
+        val durationMs = System.currentTimeMillis() - startTime
 
         return CompletionData(
             prompt = prompt,
@@ -104,6 +106,7 @@ class Claude(
             images = imagesBase64,
             model = actualModel,
             response = response.content.first().text!!,
+            durationMs = durationMs,
         )
     }
 

--- a/maestro-ai/src/main/java/maestro/ai/cloud/ApiClient.kt
+++ b/maestro-ai/src/main/java/maestro/ai/cloud/ApiClient.kt
@@ -63,6 +63,12 @@ data class ExtractPointValidationResponse(
     val reasoning: String,
 )
 
+data class AIResponse<T>(
+    val result: T,
+    val durationMs: Long,
+    val model: String,
+)
+
 class ApiClient {
     private val baseUrl by lazy {
         System.getenv("MAESTRO_CLOUD_API_URL") ?: "https://api.copilot.mobile.dev"

--- a/maestro-ai/src/main/java/maestro/ai/cloud/OpenAIClient.kt
+++ b/maestro-ai/src/main/java/maestro/ai/cloud/OpenAIClient.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import maestro.ai.AI
 import maestro.ai.openai.OpenAI
+import maestro.ai.cloud.AIResponse
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(OpenAIClient::class.java)
@@ -63,7 +64,7 @@ class OpenAIClient {
         aiClient: AI,
         query: String,
         screen: ByteArray,
-    ): ExtractTextWithAiResponse {
+    ): AIResponse<ExtractTextWithAiResponse> {
         val prompt = buildString {
             append("What text on the screen matches the following query: $query")
 
@@ -99,7 +100,7 @@ class OpenAIClient {
         )
 
         val response = json.decodeFromString<ExtractTextWithAiResponse>(aiResponse.response)
-        return response
+        return AIResponse(result = response, durationMs = aiResponse.durationMs, model = aiResponse.model)
     }
 
     suspend fun extractPointWithAi(
@@ -107,7 +108,7 @@ class OpenAIClient {
         query: String,
         screen: ByteArray,
         viewHierarchy: String? = null,
-    ): ExtractPointWithReasoningResponse {
+    ): AIResponse<ExtractPointWithReasoningResponse> {
         val prompt = buildString {
             append("You are a UI element locator. Find the center coordinates of the UI element described by this query: $query")
 
@@ -159,7 +160,8 @@ class OpenAIClient {
             jsonSchema = json.parseToJsonElement(extractPointWithReasoningSchema).jsonObject,
         )
         logger.info("AI extractPointWithAi response: ${aiResponse.response}")
-        return json.decodeFromString<ExtractPointWithReasoningResponse>(aiResponse.response)
+        val result = json.decodeFromString<ExtractPointWithReasoningResponse>(aiResponse.response)
+        return AIResponse(result = result, durationMs = aiResponse.durationMs, model = aiResponse.model)
     }
 
     suspend fun extractPointRefined(
@@ -167,7 +169,7 @@ class OpenAIClient {
         query: String,
         croppedScreen: ByteArray,
         contextDescription: String,
-    ): ExtractPointWithReasoningResponse {
+    ): AIResponse<ExtractPointWithReasoningResponse> {
         val prompt = buildString {
             append("You are a UI element locator performing a REFINEMENT pass. ")
             append("You previously identified an element matching this query: $query")
@@ -213,7 +215,8 @@ class OpenAIClient {
             jsonSchema = json.parseToJsonElement(extractPointWithReasoningSchema).jsonObject,
         )
         logger.info("AI extractPointRefined response: ${aiResponse.response}")
-        return json.decodeFromString<ExtractPointWithReasoningResponse>(aiResponse.response)
+        val result = json.decodeFromString<ExtractPointWithReasoningResponse>(aiResponse.response)
+        return AIResponse(result = result, durationMs = aiResponse.durationMs, model = aiResponse.model)
     }
 
     suspend fun validatePoint(
@@ -222,7 +225,7 @@ class OpenAIClient {
         screen: ByteArray,
         pointXPercent: Int,
         pointYPercent: Int,
-    ): ExtractPointValidationResponse {
+    ): AIResponse<ExtractPointValidationResponse> {
         val prompt = buildString {
             append("You are a UI element locator performing a VALIDATION pass. ")
             append("We believe the UI element matching this query is located at coordinates ${pointXPercent}%,${pointYPercent}% on the screen: $query")
@@ -262,7 +265,8 @@ class OpenAIClient {
             jsonSchema = json.parseToJsonElement(extractPointValidationSchema).jsonObject,
         )
         logger.info("AI validatePoint response: ${aiResponse.response}")
-        return json.decodeFromString<ExtractPointValidationResponse>(aiResponse.response)
+        val result = json.decodeFromString<ExtractPointValidationResponse>(aiResponse.response)
+        return AIResponse(result = result, durationMs = aiResponse.durationMs, model = aiResponse.model)
     }
 
     suspend fun extractComponentPoint(
@@ -270,7 +274,7 @@ class OpenAIClient {
         componentImage: ByteArray,
         screen: ByteArray,
         viewHierarchy: String? = null,
-    ): ExtractPointWithReasoningResponse {
+    ): AIResponse<ExtractPointWithReasoningResponse> {
         val prompt = buildString {
             append("You are a UI element locator. The FIRST image is a reference UI component (e.g., a Storybook snapshot). The SECOND image is the current device screen.")
             append(" Find where this component appears on the screen and return the center coordinates of the matching area.")
@@ -323,14 +327,15 @@ class OpenAIClient {
             jsonSchema = json.parseToJsonElement(extractPointWithReasoningSchema).jsonObject,
         )
         logger.info("AI extractComponentPoint response: ${aiResponse.response}")
-        return json.decodeFromString<ExtractPointWithReasoningResponse>(aiResponse.response)
+        val result = json.decodeFromString<ExtractPointWithReasoningResponse>(aiResponse.response)
+        return AIResponse(result = result, durationMs = aiResponse.durationMs, model = aiResponse.model)
     }
 
     suspend fun findDefects(
         aiClient: AI,
         screen: ByteArray,
         assertion: String? = null,
-    ): FindDefectsResponse {
+    ): AIResponse<FindDefectsResponse> {
 
         if(assertion !== null) {
             return performAssertion(aiClient, screen, assertion)
@@ -404,14 +409,14 @@ class OpenAIClient {
         )
 
         val defects = json.decodeFromString<FindDefectsResponse>(aiResponse.response)
-        return defects
+        return AIResponse(result = defects, durationMs = aiResponse.durationMs, model = aiResponse.model)
     }
 
     private suspend fun performAssertion(
         aiClient: AI,
         screen: ByteArray,
         assertion: String,
-    ): FindDefectsResponse{
+    ): AIResponse<FindDefectsResponse> {
         val prompt = buildString {
 
             appendLine(
@@ -448,6 +453,6 @@ class OpenAIClient {
         )
 
         val response = json.decodeFromString<FindDefectsResponse>(aiResponse.response)
-        return response
+        return AIResponse(result = response, durationMs = aiResponse.durationMs, model = aiResponse.model)
     }
 }

--- a/maestro-ai/src/main/java/maestro/ai/openai/Client.kt
+++ b/maestro-ai/src/main/java/maestro/ai/openai/Client.kt
@@ -76,6 +76,7 @@ class OpenAI(
             ),
         )
 
+        val startTime = System.currentTimeMillis()
         val chatCompletionResponse = try {
             val httpResponse = httpClient.post(API_URL) {
                 contentType(ContentType.Application.Json)
@@ -97,6 +98,7 @@ class OpenAI(
             logger.error("Failed to complete request to OpenAI", e)
             throw e
         }
+        val durationMs = System.currentTimeMillis() - startTime
 
         return CompletionData(
             prompt = prompt,
@@ -105,6 +107,7 @@ class OpenAI(
             images = imagesBase64,
             model = actualModel,
             response = chatCompletionResponse.choices.first().message.content,
+            durationMs = durationMs,
         )
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/report/AIMetricsHtmlReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/AIMetricsHtmlReporter.kt
@@ -1,0 +1,268 @@
+package maestro.cli.report
+
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import java.io.File
+
+object AIMetricsHtmlReporter {
+
+    private val logger = LoggerFactory.getLogger(AIMetricsHtmlReporter::class.java)
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun generateReport(): File? {
+        val metricsDir = File(System.getProperty("user.home"), ".maestro/ai-metrics")
+        if (!metricsDir.exists()) return null
+
+        val jsonFiles = metricsDir.listFiles { f -> f.extension == "json" } ?: return null
+        if (jsonFiles.isEmpty()) return null
+
+        val runs = jsonFiles.mapNotNull { file ->
+            try {
+                json.decodeFromString(AIMetricsRun.serializer(), file.readText())
+            } catch (e: Exception) {
+                logger.warn("Failed to parse metrics file: ${file.name}", e)
+                null
+            }
+        }.sortedBy { it.timestamp }
+
+        if (runs.isEmpty()) return null
+
+        val runsJson = Json { prettyPrint = false }.encodeToString(
+            kotlinx.serialization.builtins.ListSerializer(AIMetricsRun.serializer()),
+            runs,
+        )
+
+        val html = buildHtml(runsJson, runs)
+        val outputFile = File(metricsDir, "ai-agents-performance-report.html")
+        outputFile.writeText(html)
+        logger.info("AI metrics HTML report: ${outputFile.absolutePath}")
+        return outputFile
+    }
+
+    private fun buildHtml(runsJson: String, runs: List<AIMetricsRun>): String {
+        // Aggregate stats per model
+        data class ModelStats(
+            var totalCalls: Int = 0,
+            var successfulCalls: Int = 0,
+            var totalLatencyMs: Long = 0,
+            var runCount: Int = 0,
+        )
+
+        val modelStatsMap = mutableMapOf<String, ModelStats>()
+        for (run in runs) {
+            val stats = modelStatsMap.getOrPut(run.model) { ModelStats() }
+            stats.totalCalls += run.summary.totalCalls
+            stats.successfulCalls += run.summary.successfulCalls
+            stats.totalLatencyMs += run.summary.totalLatencyMs
+            stats.runCount++
+        }
+
+        val summaryCardsHtml = buildString {
+            append("<div class=\"summary-cards\">")
+            for ((model, stats) in modelStatsMap) {
+                val avgLatency = if (stats.totalCalls > 0) stats.totalLatencyMs / stats.totalCalls else 0
+                val successRate = if (stats.totalCalls > 0) (stats.successfulCalls * 100.0 / stats.totalCalls) else 0.0
+                append("""
+                    <div class="card">
+                        <h3>$model</h3>
+                        <div class="stat"><span class="label">Runs:</span> ${stats.runCount}</div>
+                        <div class="stat"><span class="label">Total Calls:</span> ${stats.totalCalls}</div>
+                        <div class="stat"><span class="label">Success Rate:</span> ${"%.1f".format(successRate)}%</div>
+                        <div class="stat"><span class="label">Avg Latency:</span> ${avgLatency}ms</div>
+                    </div>
+                """)
+            }
+            append("</div>")
+        }
+
+        val runsTableHtml = buildString {
+            append("""
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Timestamp</th>
+                            <th>Model</th>
+                            <th>Provider</th>
+                            <th>Total Calls</th>
+                            <th>Success Rate</th>
+                            <th>Avg Latency (ms)</th>
+                            <th>Total Latency (ms)</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+            """)
+            for (run in runs.reversed()) {
+                val successRate = if (run.summary.totalCalls > 0)
+                    "%.1f".format(run.summary.successfulCalls * 100.0 / run.summary.totalCalls)
+                else "N/A"
+                append("""
+                    <tr>
+                        <td>${run.timestamp}</td>
+                        <td>${run.model}</td>
+                        <td>${run.provider}</td>
+                        <td>${run.summary.totalCalls}</td>
+                        <td>${successRate}%</td>
+                        <td>${run.summary.avgLatencyMs}</td>
+                        <td>${run.summary.totalLatencyMs}</td>
+                    </tr>
+                """)
+            }
+            append("</tbody></table>")
+        }
+
+        return """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Agents Performance Report</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; color: #333; padding: 20px; }
+        h1 { text-align: center; margin-bottom: 10px; color: #1a1a1a; }
+        .subtitle { text-align: center; color: #666; margin-bottom: 30px; }
+        .summary-cards { display: flex; gap: 20px; justify-content: center; flex-wrap: wrap; margin-bottom: 30px; }
+        .card { background: white; border-radius: 8px; padding: 20px; min-width: 200px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .card h3 { margin-bottom: 10px; color: #2563eb; font-size: 14px; word-break: break-all; }
+        .stat { margin: 5px 0; font-size: 14px; }
+        .stat .label { font-weight: 600; }
+        .charts { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 30px; }
+        .chart-container { background: white; border-radius: 8px; padding: 20px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .chart-container h3 { margin-bottom: 15px; font-size: 16px; }
+        canvas { max-height: 300px; }
+        table { width: 100%; border-collapse: collapse; background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        th, td { padding: 10px 15px; text-align: left; border-bottom: 1px solid #eee; font-size: 13px; }
+        th { background: #f8f9fa; font-weight: 600; }
+        tr:hover { background: #f8f9fa; }
+        h2 { margin: 20px 0 15px; }
+        @media (max-width: 768px) { .charts { grid-template-columns: 1fr; } }
+    </style>
+</head>
+<body>
+    <h1>AI Agents Performance Report</h1>
+    <p class="subtitle">Auto-generated comparison of AI providers across test runs</p>
+
+    $summaryCardsHtml
+
+    <div class="charts">
+        <div class="chart-container">
+            <h3>Average Latency by Model</h3>
+            <canvas id="latencyChart"></canvas>
+        </div>
+        <div class="chart-container">
+            <h3>Success Rate by Model</h3>
+            <canvas id="successChart"></canvas>
+        </div>
+        <div class="chart-container">
+            <h3>Latency Over Time</h3>
+            <canvas id="latencyTimeChart"></canvas>
+        </div>
+        <div class="chart-container">
+            <h3>Success Rate Over Time</h3>
+            <canvas id="successTimeChart"></canvas>
+        </div>
+    </div>
+
+    <h2>Run History</h2>
+    $runsTableHtml
+
+    <script>
+        const runs = $runsJson;
+
+        // Aggregate by model
+        const modelData = {};
+        runs.forEach(run => {
+            if (!modelData[run.model]) {
+                modelData[run.model] = { totalCalls: 0, successCalls: 0, totalLatency: 0 };
+            }
+            modelData[run.model].totalCalls += run.summary.totalCalls;
+            modelData[run.model].successCalls += run.summary.successfulCalls;
+            modelData[run.model].totalLatency += run.summary.totalLatencyMs;
+        });
+
+        const models = Object.keys(modelData);
+        const colors = ['#2563eb', '#dc2626', '#16a34a', '#ea580c', '#7c3aed', '#0891b2'];
+
+        // Latency pie chart
+        new Chart(document.getElementById('latencyChart'), {
+            type: 'bar',
+            data: {
+                labels: models,
+                datasets: [{
+                    label: 'Avg Latency (ms)',
+                    data: models.map(m => modelData[m].totalCalls > 0 ? Math.round(modelData[m].totalLatency / modelData[m].totalCalls) : 0),
+                    backgroundColor: colors.slice(0, models.length),
+                }]
+            },
+            options: { responsive: true, plugins: { legend: { display: false } } }
+        });
+
+        // Success rate pie chart
+        new Chart(document.getElementById('successChart'), {
+            type: 'pie',
+            data: {
+                labels: models,
+                datasets: [{
+                    data: models.map(m => modelData[m].totalCalls > 0 ? parseFloat((modelData[m].successCalls * 100 / modelData[m].totalCalls).toFixed(1)) : 0),
+                    backgroundColor: colors.slice(0, models.length),
+                }]
+            },
+            options: { responsive: true }
+        });
+
+        // Latency over time line chart
+        const modelTimeSeries = {};
+        runs.forEach(run => {
+            if (!modelTimeSeries[run.model]) modelTimeSeries[run.model] = [];
+            modelTimeSeries[run.model].push({ x: run.timestamp, y: run.summary.avgLatencyMs });
+        });
+
+        new Chart(document.getElementById('latencyTimeChart'), {
+            type: 'line',
+            data: {
+                datasets: Object.keys(modelTimeSeries).map((model, i) => ({
+                    label: model,
+                    data: modelTimeSeries[model],
+                    borderColor: colors[i % colors.length],
+                    fill: false,
+                    tension: 0.1,
+                }))
+            },
+            options: {
+                responsive: true,
+                scales: { x: { type: 'category', labels: [...new Set(runs.map(r => r.timestamp))] }, y: { title: { display: true, text: 'ms' } } }
+            }
+        });
+
+        // Success rate over time line chart
+        const modelSuccessTimeSeries = {};
+        runs.forEach(run => {
+            if (!modelSuccessTimeSeries[run.model]) modelSuccessTimeSeries[run.model] = [];
+            const rate = run.summary.totalCalls > 0 ? parseFloat((run.summary.successfulCalls * 100 / run.summary.totalCalls).toFixed(1)) : 0;
+            modelSuccessTimeSeries[run.model].push({ x: run.timestamp, y: rate });
+        });
+
+        new Chart(document.getElementById('successTimeChart'), {
+            type: 'line',
+            data: {
+                datasets: Object.keys(modelSuccessTimeSeries).map((model, i) => ({
+                    label: model,
+                    data: modelSuccessTimeSeries[model],
+                    borderColor: colors[i % colors.length],
+                    fill: false,
+                    tension: 0.1,
+                }))
+            },
+            options: {
+                responsive: true,
+                scales: { x: { type: 'category', labels: [...new Set(runs.map(r => r.timestamp))] }, y: { title: { display: true, text: '%' }, min: 0, max: 100 } }
+            }
+        });
+    </script>
+</body>
+</html>
+        """.trimIndent()
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/report/AIMetricsReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/AIMetricsReporter.kt
@@ -1,0 +1,104 @@
+package maestro.cli.report
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import maestro.orchestra.Orchestra
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Serializable
+data class AICallMetricJson(
+    val model: String,
+    val durationMs: Long,
+    val success: Boolean,
+)
+
+@Serializable
+data class FlowAIMetrics(
+    val flowName: String,
+    val aiCalls: List<AICallMetricJson>,
+)
+
+@Serializable
+data class AIMetricsSummary(
+    val totalCalls: Int,
+    val successfulCalls: Int,
+    val failedCalls: Int,
+    val avgLatencyMs: Long,
+    val totalLatencyMs: Long,
+)
+
+@Serializable
+data class AIMetricsRun(
+    val timestamp: String,
+    val model: String,
+    val provider: String,
+    val flows: List<FlowAIMetrics>,
+    val summary: AIMetricsSummary,
+)
+
+object AIMetricsReporter {
+
+    private val logger = LoggerFactory.getLogger(AIMetricsReporter::class.java)
+    private val json = Json { prettyPrint = true }
+
+    fun writeMetrics(
+        flowMetrics: Map<String, List<Orchestra.AICallMetric>>,
+    ): File? {
+        if (flowMetrics.values.all { it.isEmpty() }) {
+            logger.info("No AI metrics to write")
+            return null
+        }
+
+        val metricsDir = File(System.getProperty("user.home"), ".maestro/ai-metrics")
+        metricsDir.mkdirs()
+
+        val allCalls = flowMetrics.values.flatten()
+        val model = allCalls.firstOrNull()?.model ?: "unknown"
+        val provider = when {
+            model.startsWith("gpt-") -> "openai"
+            model.startsWith("claude-") -> "anthropic"
+            else -> "unknown"
+        }
+
+        val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))
+        val fileTimestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"))
+
+        val flows = flowMetrics.map { (flowName, metrics) ->
+            FlowAIMetrics(
+                flowName = flowName,
+                aiCalls = metrics.map { AICallMetricJson(model = it.model, durationMs = it.durationMs, success = it.success) },
+            )
+        }
+
+        val totalCalls = allCalls.size
+        val successfulCalls = allCalls.count { it.success }
+        val failedCalls = totalCalls - successfulCalls
+        val totalLatencyMs = allCalls.sumOf { it.durationMs }
+        val avgLatencyMs = if (totalCalls > 0) totalLatencyMs / totalCalls else 0
+
+        val run = AIMetricsRun(
+            timestamp = timestamp,
+            model = model,
+            provider = provider,
+            flows = flows,
+            summary = AIMetricsSummary(
+                totalCalls = totalCalls,
+                successfulCalls = successfulCalls,
+                failedCalls = failedCalls,
+                avgLatencyMs = avgLatencyMs,
+                totalLatencyMs = totalLatencyMs,
+            ),
+        )
+
+        val fileName = "${fileTimestamp}_${model}.json"
+        val outputFile = File(metricsDir, fileName)
+        outputFile.writeText(json.encodeToString(run))
+        logger.info("AI metrics written to: ${outputFile.absolutePath}")
+
+        return outputFile
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -18,6 +18,8 @@ import maestro.cli.view.ErrorViewUtils
 import maestro.cli.view.TestSuiteStatusView
 import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel
 import maestro.orchestra.Orchestra
+import maestro.cli.report.AIMetricsReporter
+import maestro.cli.report.AIMetricsHtmlReporter
 import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import maestro.orchestra.yaml.YamlCommandReader
@@ -58,6 +60,7 @@ class TestSuiteInteractor(
 
     private val logger = LoggerFactory.getLogger(TestSuiteInteractor::class.java)
     private val shardPrefix = shardIndex?.let { "[shard ${it + 1}] " }.orEmpty()
+    private val aiMetricsPerFlow = mutableMapOf<String, MutableList<Orchestra.AICallMetric>>()
 
     suspend fun runTestSuite(
         executionPlan: WorkspaceExecutionPlanner.ExecutionPlan,
@@ -157,6 +160,19 @@ class TestSuiteInteractor(
 
         // TODO(bartekpacia): Should it also be saving to debugOutputPath?
         TestDebugReporter.saveSuggestions(aiOutputs, debugOutputPath)
+
+        // Write AI metrics and generate HTML report
+        try {
+            val metricsFile = AIMetricsReporter.writeMetrics(aiMetricsPerFlow)
+            if (metricsFile != null) {
+                val reportFile = AIMetricsHtmlReporter.generateReport()
+                if (reportFile != null) {
+                    PrintUtils.message("AI metrics report: ${reportFile.absolutePath}")
+                }
+            }
+        } catch (e: Exception) {
+            logger.warn("Failed to write AI metrics report", e)
+        }
 
         return summary
     }
@@ -293,6 +309,16 @@ class TestSuiteInteractor(
                                 defects = defects,
                             )
                         )
+                    },
+                    onCommandMetadataUpdate = { _, metadata ->
+                        if (metadata.aiMetrics.isNotEmpty()) {
+                            val flowMetrics = aiMetricsPerFlow.getOrPut(flowName) { mutableListOf() }
+                            for (metric in metadata.aiMetrics) {
+                                if (!flowMetrics.contains(metric)) {
+                                    flowMetrics.add(metric)
+                                }
+                            }
+                        }
                     }
                 )
 


### PR DESCRIPTION
## Proposed changes

https://goeuro.atlassian.net/browse/UP-4291

  - Auto-alternate between OpenAI and Anthropic providers across runs using new `MAESTRO_CLI_AI_KEY_ALT` / `MAESTRO_CLI_AI_MODEL_ALT` env vars (round-robin persisted in `~/.maestro/ai-metrics/.last_provider`)
  - Instrument all AI API calls with latency timing and success/failure tracking                                                                                                                                                       
  - Write per-run JSON metrics to `~/.maestro/ai-metrics/` and auto-generate an HTML report with Chart.js charts comparing provider speed and accuracy 


## Testing

  - Set both primary and alternate env vars, run tests twice, verify provider alternation in logs (`[Orchestra] AI provider:`)
  - Check `~/.maestro/ai-metrics/*.json` for per-run metrics files
  - Open `~/.maestro/ai-metrics/ai-agents-performance-report.html` and verify charts render

