### PR TITLE
Resolve component image path from app root derived from flow file path

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -704,16 +704,8 @@ class Orchestra(
         val reasoningLog = StringBuilder()
         reasoningLog.appendLine("Image: \"${command.imagePath}\"")
 
-        // Resolve image path: if relative and APP_ROOT is set, resolve against it
-        val imageFile = File(command.imagePath).let { file ->
-            if (file.isAbsolute) file
-            else {
-                val appRoot = System.getenv("APP_ROOT")
-                if (appRoot != null) File(appRoot, command.imagePath)
-                else file
-            }
-        }
-        val componentImageBytes = imageFile.readBytes()
+        // Image path is resolved to absolute at parse time
+        val componentImageBytes = File(command.imagePath).readBytes()
 
         // Take screenshot
         val imageData = Buffer()

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -255,10 +255,11 @@ data class YamlFluentCommand(
             )
 
             extractComponentWithAI != null -> {
+                val resolvedImagePath = resolveComponentImagePath(flowPath, extractComponentWithAI.image)
                 listOf(
                     MaestroCommand(
                         ExtractComponentWithAICommand(
-                            imagePath = extractComponentWithAI.image,
+                            imagePath = resolvedImagePath,
                             outputVariable = extractComponentWithAI.outputVariable,
                             optional = extractComponentWithAI.optional,
                             label = extractComponentWithAI.label,
@@ -748,6 +749,18 @@ data class YamlFluentCommand(
             throw InvalidFlowFile("Flow file can't be a directory: ${resolvedPath.toUri()}", resolvedPath)
         }
         return resolvedPath
+    }
+
+    private fun resolveComponentImagePath(flowPath: Path, imagePath: String): String {
+        val path = flowPath.fileSystem.getPath(imagePath)
+        if (path.isAbsolute) {
+            return path.toString()
+        }
+        // Derive app root from flow path (e.g., /Users/.../StudioProjects/app/packages/... -> /Users/.../StudioProjects/app)
+        val flowPathStr = flowPath.toString()
+        val appRootPrefix = flowPathStr.split("/app/")[0]
+        val resolvedPath = flowPath.fileSystem.getPath("$appRootPrefix/app/$imagePath")
+        return resolvedPath.toString()
     }
 
     private fun extendedWait(command: YamlExtendedWaitUntil): MaestroCommand {


### PR DESCRIPTION
## Proposed changes

  - Resolves extractComponentWithAI image paths relative to the app/ root, derived automatically from the flow file path
  - Removes the need for an APP_ROOT environment variable
  - Absolute paths are still supported as-is

