### PR TITLE
feat: introduce condition met with ai

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Condition.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Condition.kt
@@ -9,6 +9,7 @@ data class Condition(
     val visible: ElementSelector? = null,
     val notVisible: ElementSelector? = null,
     val scriptCondition: String? = null,
+    val conditionsMetWithAI: String? = null,
     val label: String? = null,
 ) {
 
@@ -17,6 +18,7 @@ data class Condition(
             visible = visible?.evaluateScripts(jsEngine),
             notVisible = notVisible?.evaluateScripts(jsEngine),
             scriptCondition = scriptCondition?.evaluateScripts(jsEngine),
+            conditionsMetWithAI = conditionsMetWithAI?.evaluateScripts(jsEngine),
         )
     }
 
@@ -41,6 +43,10 @@ data class Condition(
 
         scriptCondition?.let {
             descriptions.add("$it is true")
+        }
+
+        conditionsMetWithAI?.let {
+            descriptions.add("AI conditions: $it are met")
         }
 
         return if (descriptions.isEmpty()) {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -460,7 +460,7 @@ class Orchestra(
         return true
     }
 
-    private fun assertConditionCommand(command: AssertConditionCommand): Boolean {
+    private suspend fun assertConditionCommand(command: AssertConditionCommand): Boolean {
         val timeout = (command.timeoutMs() ?: lookupTimeoutMs)
         val debugMessage = """
             Assertion '${command.condition.description()}' failed. Check the UI hierarchy in debug artifacts to verify the element state and properties.
@@ -842,7 +842,7 @@ class Orchestra(
         return true
     }
 
-    private fun runScriptCommand(command: RunScriptCommand): Boolean {
+    private suspend fun runScriptCommand(command: RunScriptCommand): Boolean {
         return if (evaluateCondition(command.condition, commandOptional = command.optional)) {
             jsEngine.evaluateScript(
                 script = command.script,
@@ -1019,7 +1019,7 @@ class Orchestra(
 
         var mutating = false
 
-        val checkCondition: () -> Boolean = {
+        val checkCondition: suspend () -> Boolean = {
             command.condition
                 ?.evaluateScripts(jsEngine)
                 ?.let { evaluateCondition(it, commandOptional = command.optional) } != false
@@ -1098,7 +1098,7 @@ class Orchestra(
         }
     }
 
-    private fun evaluateCondition(
+    private suspend fun evaluateCondition(
         condition: Condition?,
         commandOptional: Boolean,
         timeoutMs: Long? = null,
@@ -1135,6 +1135,17 @@ class Orchestra(
             if (value.toDoubleOrNull() == 0.0) {
                 return false
             }
+        }
+
+        condition.conditionsMetWithAI?.let { assertion ->
+            val imageData = Buffer()
+            maestro.takeScreenshot(imageData, compressed = false)
+            val defect = AIPredictionEngine.performAssertion(
+                screen = imageData.readByteArray(),
+                aiClient = ai,
+                assertion = assertion,
+            )
+            if (defect != null) return false
         }
 
         condition.visible?.let {
@@ -1392,7 +1403,7 @@ class Orchestra(
         return true
     }
 
-    private fun assertCommand(command: AssertCommand): Boolean {
+    private suspend fun assertCommand(command: AssertCommand): Boolean {
         return assertConditionCommand(
             command.toAssertConditionCommand()
         )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCondition.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCondition.kt
@@ -9,6 +9,7 @@ data class YamlCondition(
     val visible: YamlElementSelectorUnion? = null,
     val notVisible: YamlElementSelectorUnion? = null,
     val `true`: String? = null,
+    val conditionsMetWithAI: String? = null,
     val label: String? = null,
     val optional: Boolean = false,
 )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -1053,6 +1053,7 @@ data class YamlFluentCommand(
             visible = visible?.let { toElementSelector(it) },
             notVisible = notVisible?.let { toElementSelector(it) },
             scriptCondition = `true`?.trim(),
+            conditionsMetWithAI = conditionsMetWithAI?.trim(),
             label = label
         )
     }


### PR DESCRIPTION
## Proposed changes

https://goeuro.atlassian.net/browse/UP-4427

Add `conditionsMetWithAI` to the when: condition system, enabling AI-powered conditional execution that skips commands when screen assertions aren't met instead of failing the flow. 

